### PR TITLE
fix(users): fixing the type mismatch

### DIFF
--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -681,7 +681,7 @@ Created: ${formatDate(user.created)}`,
 
       // Use the system log API to get login events
       const logs = await oktaClient.systemLogApi.listLogEvents({
-        since: ninetyDaysAgo,
+        since: ninetyDaysAgo.toISOString(),
         filter: `target.id eq "${userId}" and (eventType eq "user.session.start" or eventType eq "user.authentication.auth_via_mfa" or eventType eq "user.authentication.sso")`,
         limit: 1,
       });


### PR DESCRIPTION
This pull request includes a small but important change to the `src/tools/users.ts` file. The change ensures that the `since` parameter in the `listLogEvents` method is correctly formatted as an ISO string, improving compatibility with the Okta API.